### PR TITLE
Add scripts to configure a Google Cloud project for actions.

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -28,7 +28,7 @@ jobs:
 
     env:
       registry-yaml: entity.yaml
-      workload_identity_provider: "projects/459884772743/locations/global/workloadIdentityPools/github/providers/github"
+      workload_identity_provider: "projects/459884772743/locations/global/workloadIdentityPools/registry/providers/registry"
       service_account: "registry-editor@apigee-apihub-demo.iam.gserviceaccount.com"
 
     permissions:

--- a/tools/CONFIG-ACTION.sh
+++ b/tools/CONFIG-ACTION.sh
@@ -16,7 +16,7 @@
 #
 
 # This file sets variables that allow a GitHub Action associated
-# with this repository.to use Workload Identity Federation.
+# with this repository to use Workload Identity Federation.
 #
 # There are many possible ways to configure this. For full
 # details see the official documentation at:

--- a/tools/CONFIG-ACTION.sh
+++ b/tools/CONFIG-ACTION.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file sets variables that allow a GitHub Action associated
+# with this repository.to use Workload Identity Federation.
+#
+# There are many possible ways to configure this. For full
+# details see the official documentation at:
+#   https://cloud.google.com/iam/docs/workload-identity-federation
+#
+# Here we set variables used by other scripts that allow an action
+# running under a specified GitHub owner to use a service account
+# that is configured to have edit access to the Registry API.
+
+# ACTION: Set this to the owner of your repo (a GitHub organization
+# or user name).
+GITHUB_OWNER=apigee-apihub-demo
+
+# ACTION: Set these variables to the name and number of the Google
+# Cloud project where your Registry API instance is running.
+PROJECT_ID=apigee-apihub-demo
+PROJECT_NUMBER=459884772743
+
+# ACTION: Review these names. They are arbitrary and you probably
+# won't need to change them. The pool ID and Service Account email
+# must match values in your GitHub Action. Note that if you delete
+# a pool, its ID will be unusable for a significant period of time
+# afterwards (currently 30 days).
+POOL_ID=registry
+PROVIDER_ID=registry
+SERVICE_ACCOUNT_ID=registry-editor
+
+# This automatically derives the full name of the service account that's
+# used to call the Registry API. You probably won't need to change it.
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"

--- a/tools/SETUP-ACTION.sh
+++ b/tools/SETUP-ACTION.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script configures a Google Cloud project to allow a GitHub Action
+# associated with this repository to make mutating calls to the Registry API.
+# It should be run from the root of this repository, e.g.
+#   % ./tools/SETUP-ACTION.sh
+
+# Load some common configuration. See this file for user-editable values.
+source ./tools/CONFIG-ACTION.sh
+
+# Create the service account that will be used to perform actions on the registry.
+gcloud iam service-accounts create ${SERVICE_ACCOUNT_ID} \
+  --display-name="Registry Editor"
+
+# Give the service account the "apigeeregistry.editor" role.
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member=serviceAccount:${SERVICE_ACCOUNT} \
+  --role=roles/apigeeregistry.editor
+
+# This workload identity pool will generate credentials as needed.
+gcloud iam workload-identity-pools create ${POOL_ID} \
+  --project=${PROJECT_ID} \
+  --location=global \
+  --display-name="GitHub Actions Activity Pool"
+
+# This provider authenticates users based on the owner of the repo running the action.
+gcloud iam workload-identity-pools providers create-oidc ${PROVIDER_ID} \
+  --project=${PROJECT_ID} \
+  --location=global \
+  --workload-identity-pool=${POOL_ID} \
+  --display-name="Registry Provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.owner=assertion.repository_owner" \
+  --attribute-condition="attribute.owner == '${GITHUB_OWNER}'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+# This binding allows the workload provider to act as the service account identity.
+gcloud iam service-accounts add-iam-policy-binding ${SERVICE_ACCOUNT} \
+  --project=${PROJECT_ID} \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_ID}/*"

--- a/tools/TEARDOWN-ACTION.sh
+++ b/tools/TEARDOWN-ACTION.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright 2023 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script removes configuration that was added by SETUP-ACTION.sh.
+# It should be run from the root of this repository, e.g.
+#   % ./tools/SETUP-ACTION.sh
+
+# Note that if you run this and re-run SETUP-ACTION.sh, you will need to
+# specify a new POOL_ID.
+
+# Load some common configuration. See this file for user-editable values.
+source ./tools/CONFIG-ACTION.sh
+
+# Delete the service account.
+gcloud iam service-accounts delete ${SERVICE_ACCOUNT}
+
+# Delete the workload identity pool and all its child resources.
+gcloud iam workload-identity-pools delete ${POOL_ID} --location=global


### PR DESCRIPTION
Finishes #1 by making the example fully reproducible. I verified several setup-teardown cycles on a test repo. It should now be possible to take a copy of this repo, adjust values in `./tools/CONFIG-ACTIONS.sh` and `.github/workflows/apply.yaml`, and run `./tools/SETUP-ACTIONS.sh` to configure a Google Cloud project to accept requests from the `apply.yaml` workflow.