### PR TITLE
Add arm64 builds to CI.

### DIFF
--- a/.github/workflows/composite/build-push/action.yml
+++ b/.github/workflows/composite/build-push/action.yml
@@ -41,6 +41,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    # https://github.com/docker/setup-buildx-action
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
     - name: Log into registry ${{ env.REGISTRY }}
       if: github.event_name != 'pull_request'
       uses: docker/login-action@v2
@@ -58,7 +64,6 @@ runs:
           type=ref,event=tag
           type=schedule,pattern=nightly
           type=raw,latest
-
     - name: Build and push Docker image
       uses: docker/build-push-action@v4
       with:
@@ -67,4 +72,5 @@ runs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64
         build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
This updates CI to use [Docker buildx](https://github.com/docker/buildx), which makes it easy for us to use CI to build multi-architecture images. Currently it's just adding `linux/arm64`, but others could be easily added.

As we proliferate repos, I think it might be worthwhile to move our [composite build-push action](https://github.com/apigee-apihub-demo/petstore/blob/main/.github/workflows/composite/build-push/action.yml) into a common place that we could share across repos, at least in the [apigee-apihub-demo](https://apigee-apihub-demo) org.